### PR TITLE
Include node name in restart notification

### DIFF
--- a/src/kubernetes.rs
+++ b/src/kubernetes.rs
@@ -208,6 +208,7 @@ async fn describe_container_status(
         pod_name: p.name_any(),
         container_name: container.name.clone(),
         container_image: container.image.clone(),
+        node_name: p.spec.as_ref().and_then(|s| s.node_name.clone()),
         restart_count: container.restart_count,
         last_state: get_last_state(container),
         resources: get_resources(p, container).unwrap_or_default(),

--- a/src/message.rs
+++ b/src/message.rs
@@ -17,6 +17,7 @@ pub struct ContainerRestartInfo {
     pub pod_name: String,
     pub container_name: String,
     pub container_image: String,
+    pub node_name: Option<String>,
     pub restart_count: i32,
     pub last_state: Option<ContainerState>,
     pub resources: ContainerResources,
@@ -30,11 +31,13 @@ impl ContainerRestartInfo {
             r"Namespace: {}
 Pod: `{}`
 Container Name: `{}`
-Container Image: `{}`",
+Container Image: `{}`
+Node Name: {}",
             format_name(&self.namespace),
             &self.pod_name,
             &self.container_name,
             &self.container_image,
+            format_name(&self.node_name),
         );
         let stats = build_container_stats(self.restart_count, &self.last_state);
         let resources = self.resources.to_message();


### PR DESCRIPTION
## What

TSIA

## Why

To help troubleshoot in case multiple pods restart in the same node.
